### PR TITLE
feat: Tables edit

### DIFF
--- a/src/Components/TablesView/DroppableTable.js
+++ b/src/Components/TablesView/DroppableTable.js
@@ -1,21 +1,37 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
 /**
  * DroppableTable component rendering the dragged tables onto the main div.
  * @param {Object} table - table object containing the main informations, such as table name, number of plates, positions...
  * @param {boolean} inEdit - boolean used to change style and behaviour of the tables.
+ * @param {Object} editTable Object used to know which table is currently being edited
+ * @param {Function} setEditTable state function used to update the table in edit
+ * @param {Function} setOrders state function used to update the current order
  * @returns {JSX.Element} The rendered DroppableTable component.
  */
-function DroppableTable({table, inEdit}) {
+function DroppableTable({table, inEdit, editTable, setEditTable, setOrders}) {
+
+    const [border, setBorder] = useState("border-black")
 
     const onTableClick = () => {
-        console.log("Table " + table.id + " clicked")
+        if (inEdit) {
+            setBorder("border-kitchen-button-orange")
+            setEditTable(table)
+        } else {
+            setOrders((Order) => [{ nb: table.id }, ...Order.slice(1)]);
+        }
     };
 
+    useEffect(() => {
+        if (table.top !== editTable.top && table.left !== editTable.left) {
+            setBorder("border-black")
+        }
+    }, [editTable, table])
+
     return (
-        <div onClick={() => onTableClick()} name={table.id} className={`${table.type === "circle" ? "rounded-full" : ""} border-4 absolute col-span-1 grid grid-flow-row ${inEdit === true ? "bg-grey-bg border-black grid-rows-2" : table.time === "00:00" ? "bg-kitchen-green border-kitchen-green grid-rows-3" : "bg-kitchen-yellow border-kitchen-yellow grid-rows-3"} justify-center justify-items-center`} style={{width: table.w, height: table.h, top: table.top, left: table.left}}>
-            <div className={`${table.type === "circle" ? "text-2xl" : "text-3xl"} row-span-1 self-center font-bold`}>{table.id}</div>
+        <div onClick={() => onTableClick()} name={table.id} className={`${table.type === "circle" ? "rounded-full" : ""} border-4 absolute col-span-1 grid grid-flow-row ${inEdit === true ? `bg-grey-bg ${border} grid-rows-2` : table.time === "00:00" ? "bg-kitchen-green border-kitchen-green grid-rows-3" : "bg-kitchen-yellow border-kitchen-yellow grid-rows-3"} justify-center justify-items-center`} style={{width: table.w, height: table.h, top: table.top, left: table.left}}>   
+            <div className={`${table.type === "circle" ? (table.id.length > 5 ? "text-xl" : "text-2xl") : (table.id.length > 5 ? "text-2xl" : "text-3xl")} row-span-1 self-center font-bold`}>{table.id}</div>
             <div className={`${table.type === "circle" ? "text-xl" : "text-2xl"} row-span-1 self-center`}>{table.plates} {table.type === "rectangle" ? "couverts" : "couv."}</div>
             {inEdit === false ? table.time === "00:00" ?
                 <div className="row-span-1 self-center text-1xl">{table.type === "rectangle" ? "Disponible" : "Dispo."}</div>
@@ -27,7 +43,10 @@ function DroppableTable({table, inEdit}) {
 
 DroppableTable.propTypes = {
     table: PropTypes.object.isRequired,
-    inEdit: PropTypes.bool.isRequired
+    inEdit: PropTypes.bool.isRequired,
+    editTable: PropTypes.object.isRequired,
+    setEditTable: PropTypes.func.isRequired,
+    setOrders: PropTypes.func.isRequired,
 }
 
 export default DroppableTable;

--- a/src/Components/TablesView/TablesPanel.js
+++ b/src/Components/TablesView/TablesPanel.js
@@ -1,0 +1,144 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+
+/**
+ * PlatesButton component rendering the number of plates and buttons when editing a table.
+ * @param {Object} editTable Object used to know which table is currently being edited
+ * @param {Function} setEditTable state function used to update the table in edit
+ * @returns {JSX.Element} The rendered PlatesButton component.
+ */
+function PlatesButton ({ editTable, setEditTable }) {
+
+    const handleAdd = () => {
+        setEditTable((table) => ({
+            ...table,
+            plates: table.plates + 1
+        }));
+    };
+    
+    const handleDel = () => {
+        setEditTable((table) => ({
+            ...table,
+            plates: table.plates > 0 ? table.plates - 1 : 0
+        }));
+    };
+
+    return (
+        <div className="grid grid-flow-col pt-5">
+            <div className="text-white text-4xl">
+                {`Couverts : ${editTable.plates}`}
+            </div>
+            <button onClick={() => handleAdd()} className="text-white text-4xl border-white border-y-2 border-l-2 border-r rounded-l-lg">+</button>
+            <button onClick={() => handleDel()} className="text-white text-4xl border-white border-y-2 border-r-2 rounded-r-lg">-</button>
+        </div>
+    )
+}
+
+/**
+ * EditPanel component rendering all the edits of a table
+ * @param {Object} editTable Object used to know which table is currently being edited
+ * @param {Function} setEditTable state function used to update the table in edit
+ * @returns {JSX.Element} The rendered EditPanel component.
+ */
+function EditPanel ({ editTable, setEditTable }) {
+
+    const [nameBool, setNameBool] = useState(false);
+    const [nameValue, setNameValue] = useState('');
+
+    const handleInputChange = (event) => {
+        setNameValue(event.target.value);
+    };
+
+    const handleInputSubmit = (name) => {
+        setEditTable((table) => ({
+            ...table,
+            id: name,
+        }));
+    };
+
+    const handleNameClick = () => {
+        nameBool ? setNameBool(false) : setNameBool(true);
+    }
+
+    const handleFormSubmit = (event) => {
+        event.preventDefault();
+        if (nameValue.trim() !== '') {
+            handleInputSubmit(nameValue);
+            setNameValue('');
+        }
+    }
+
+    return (
+        <div className="h-full">
+            <div className={`w-full p-2 items-center border-b-4 border-b-kitchen-yellow`}>
+                <form onSubmit={handleFormSubmit} className={`w-full h-full grid grid-flow-row ${nameBool ? "grid-rows-2" : "grid-rows-1"}`}>
+                <div className="row-span-1 text-white font-bold text-4xl items-center flex float-left">
+                    {`Table ${editTable.id}`}
+                    <button type="submit" onClick={() => handleNameClick()} className="pl-2 justify-center items-center">
+                        <img src={`./icon-drag/edit.png`} width={40} height={40} alt="Pencil image, used as a meaning to say 'edit'" />
+                    </button>
+                </div>
+                {nameBool === true &&
+                    <input
+                    type="text"
+                    className="text-2xl text-black row-span-1 border-2 rounded-full focus:outline-none px-4 float-left mt-1 mb-1 w-full"
+                    placeholder="New name"
+                    value={nameValue}
+                    onChange={handleInputChange}
+                    />
+                }
+                </form>
+            </div>
+            <PlatesButton editTable={editTable} setEditTable={setEditTable} />
+        </div>
+    )
+}
+
+
+/**
+ * TablePanel component rendering the table right panel.
+ * @param {[Object]} orders current order
+ * @param {Object} editTable Object used to know which table is currently being edited
+ * @param {Function} setEditTable state function used to update the table in edit
+ * @param {Function} setOrders state function used to update the current order
+ * @returns {JSX.Element} The rendered TablesPanel component.
+ */
+export default function TablesPanel({ orders, editTable, setEditTable, setBoard }) {
+
+    const basicTable = (
+        <div className='w-full p-2 items-center text-white font-bold text-4xl border-b-4 border-b-kitchen-yellow flex'>{`Table ${orders[0].nb}`}</div>
+    )
+
+    useEffect(() => {
+        if (editTable.id !== -1) {
+            setBoard((prevBoard) => prevBoard.map((table) =>
+                table.left === editTable.left && table.top === editTable.top ? editTable : table
+            ));
+        }
+    }, [editTable, setBoard]);
+
+    return (
+        <div className='h-full col-span-1 bg-kitchen-blue float-right flex flex-col justify-between'>
+            <div className={'w-full max-h-[80%] float-right px-2 gap-3 flex flex-col'}>
+                {editTable.id !== -1 ? <EditPanel editTable={editTable} setEditTable={setEditTable} /> : basicTable}
+            </div>
+        </div>
+    );
+}
+
+PlatesButton.propTypes = {
+    editTable: PropTypes.object.isRequired,
+    setEditTable: PropTypes.func.isRequired,
+}
+
+EditPanel.propTypes = {
+    editTable: PropTypes.object.isRequired,
+    setEditTable: PropTypes.func.isRequired,
+}
+
+TablesPanel.propTypes = {
+    orders: PropTypes.array.isRequired,
+    editTable: PropTypes.object.isRequired,
+    setEditTable: PropTypes.func.isRequired,
+    setBoard: PropTypes.func.isRequired
+}

--- a/src/Components/TablesView/TablesView.js
+++ b/src/Components/TablesView/TablesView.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 
 import { useDrop } from "react-dnd";
 import TablesFooter from "./TablesFooter";
+import TablesPanel from "./TablesPanel";
 
 import { ItemTypes } from "./Constants";
 import DroppableTable from "./DroppableTable";
@@ -14,12 +16,16 @@ const TableList = [
 
 /**
  * TableView component rendering the table page.
+ * @param {[Object]} orders current order
+ * @param {Function} setOrders state function used to update the current order
+ * @param {[Object]} board Array Object of the current POS tables
+ * @param {Function} setBoard state function used to update the tables board
  * @returns {JSX.Element} The rendered TablesView component.
  */
-export default function TablesView() {
+export default function TablesView({ orders, setOrders, board, setBoard }) {
 
-    const [board, setBoard] = useState([]);
     const [inEdit, setInEdit] = useState(false);
+    const [editTable, setEditTable] = useState({id: -1, plates: 0});
 
     const drop = useDrop(() => ({
         accept: [ItemTypes.CIRCLE, ItemTypes.SQUARE, ItemTypes.RECTANGLE],
@@ -79,21 +85,32 @@ export default function TablesView() {
         });
     };
 
-      useEffect(() => {
-    }, [board]);
+    useEffect(() => {
+        if (inEdit === false) {
+            setEditTable({id: -1, plates: 0})
+        }
+    }, [inEdit]);
 
     const boardElem = board.map((table) => (
-        <DroppableTable key={table.id} table={table} inEdit={inEdit} />
+        <DroppableTable key={table.id} table={table} inEdit={inEdit} editTable={editTable} setEditTable={setEditTable} setOrders={setOrders} />
     ));
 
     return (
-        <div className="h-full grid grid-flow-row grid-rows-10">
-            <div id="drop-area" ref={drop} className="row-span-9">
-                {boardElem}
+        <div className="h-full grid grid-flow-col grid-cols-4">
+            <div className="col-span-3 grid grid-flow-row grid-rows-10">
+                <div id="drop-area" ref={drop} className="row-span-9">
+                    {boardElem}
+                </div>
+                <TablesFooter setInEdit={setInEdit} />
             </div>
-            <TablesFooter setInEdit={setInEdit} />
+            <TablesPanel orders={orders} editTable={editTable} setEditTable={setEditTable} setBoard={setBoard} />
         </div>
     );
 }
 
-TablesView.propTypes = {}
+TablesView.propTypes = {
+    orders: PropTypes.array.isRequired,
+    setOrders: PropTypes.func.isRequired,
+    board: PropTypes.array.isRequired,
+    setBoard: PropTypes.func.isRequired,
+}

--- a/src/Pages/Layout.js
+++ b/src/Pages/Layout.js
@@ -13,7 +13,6 @@ import ManagerView from "./Manager/ManagerView";
  * Component : Main Layout of the POS Application, Main Component.
  *
  * @component Layout
- * @param {[Object]} orders current order
  * @param {Number} price full price of the current order
  * @param {Object} config state of the current order
  * @param {Function} setConfig state function to update the config of the current order
@@ -24,6 +23,10 @@ import ManagerView from "./Manager/ManagerView";
  * @param {Function} setPayList state function to update the payList
  * @param {Object} orderDetails Object of the selected food
  * @param {Function} setOrderDetails state function used to update the selected food
+ * @param {[Object]} orders current order
+ * @param {Function} setOrders state function used to update the current order
+ * @param {[Object]} tableBoard Array Object of the current POS tables
+ * @param {Function} setTableBoard state function used to update the tables board
  */
 const Layout = ({
   price,
@@ -36,7 +39,9 @@ const Layout = ({
   orderDetails,
   setOrderDetails,
   orders,
-  setOrders
+  setOrders,
+  tableBoard,
+  setTableBoard
 }) => {
   const [activeTab, setActiveTab] = useState("");
   const [selectedOrder, setSelectedOrder] = useState("");
@@ -115,15 +120,17 @@ const Layout = ({
     <div className="column w-full h-full">
       <LayoutHeader textCenter="Caisse 1" />
       <div className="w-full h-4/5">
-        <CurrentCommand
-          orders={orders}
-          config={config}
-          setConfig={setConfig}
-          setOrders={setOrders}
-          price={price}
-          priceLess={priceLess}
-          payList={payList}
-        />
+        {activeTab !== "TABLES" && (
+          <CurrentCommand
+            orders={orders}
+            config={config}
+            setConfig={setConfig}
+            setOrders={setOrders}
+            price={price}
+            priceLess={priceLess}
+            payList={payList}
+          />
+        )}
         {activeTab === "" && (
           <Outlet
             context={{
@@ -142,7 +149,7 @@ const Layout = ({
           />
         )}
         {activeTab === "TABLES" && (
-          <TablesView />
+          <TablesView orders={orders} setOrders={setOrders} board={tableBoard} setBoard={setTableBoard} />
         )}
         {activeTab === "COMMANDES" && (
           <OrdersView orderSelect={setSelectedOrder} />
@@ -177,6 +184,8 @@ Layout.propTypes = {
   setPriceLess: PropTypes.func.isRequired,
   orderDetails: PropTypes.object.isRequired,
   setOrderDetails: PropTypes.func.isRequired,
+  tableBoard: PropTypes.array.isRequired,
+  setTableBoard: PropTypes.func.isRequired,
 };
 
 export default Layout;

--- a/src/Pages/PosRouter.js
+++ b/src/Pages/PosRouter.js
@@ -35,6 +35,7 @@ function PosRouter() {
   const [payList, setPayList] = useState([]);
   const [ready, setReady] = useState(false);
   const [orderDetails, setOrderDetails] = useState({details: [], sups: []});
+  const [tableBoard, setTableBoard] = useState([]);
 
   //update the price of the current order every time the order is updated
   useEffect(() => {
@@ -55,7 +56,7 @@ function PosRouter() {
           <Routes>
             <Route path="/" element={<Login />} />
             <Route path="/loading" element={<Loading />} />
-            <Route path="/dashboard" element={<Layout orders={orders} setOrders={setOrders} price={price} config={config} setConfig={setConfig} priceLess={priceLess} setPriceLess={setPriceLess} payList={payList} setPayList={setPayList} orderDetails={orderDetails} setOrderDetails={setOrderDetails} />}>
+            <Route path="/dashboard" element={<Layout orders={orders} setOrders={setOrders} price={price} config={config} setConfig={setConfig} priceLess={priceLess} setPriceLess={setPriceLess} payList={payList} setPayList={setPayList} orderDetails={orderDetails} setOrderDetails={setOrderDetails} tableBoard={tableBoard} setTableBoard={setTableBoard} />}>
               <Route index element={<Dashboard setOrders={setOrders} orderDetails={orderDetails} setOrderDetails={setOrderDetails} />} />
               <Route path="/dashboard/pay" element={<Pay />} />
             </Route>

--- a/src/__tests__/Components/TableView/DroppableTable.test.js
+++ b/src/__tests__/Components/TableView/DroppableTable.test.js
@@ -4,21 +4,74 @@ import userEvent from "@testing-library/user-event";
 import DroppableTable from "../../../Components/TablesView/DroppableTable";
 
 describe("DroppableTable Component", () => {
-    test("renders DroppableTable correctly", () => {
+    test("renders DroppableTable", () => {
         const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
-        render(<DroppableTable table={table} inEdit={false} />);
+        render(<DroppableTable table={table} inEdit={false} editTable={{}} setEditTable={() => {}} setOrders={() => {}} />);
+        
+        expect(screen.getByText("1")).toBeInTheDocument();
+        expect(screen.getByText("2 couv.")).toBeInTheDocument();
+        expect(screen.getByText("Dispo.")).toBeInTheDocument();
+    });
+
+    test("renders DroppableTable edit mode", () => {
+        const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
+        render(<DroppableTable table={table} inEdit={true} editTable={{}} setEditTable={() => {}} setOrders={() => {}} />);
+        
         expect(screen.getByText("1")).toBeInTheDocument();
         expect(screen.getByText("2 couv.")).toBeInTheDocument();
     });
 
-    test("clicking table logs event", async () => {
-        console.log = jest.fn();
+    test("clicking table updates editTable", async () => {
+        const setEditTable = jest.fn();
+        const setOrders = jest.fn();
         const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
-        render(<DroppableTable table={table} inEdit={false} />);
-
+        const { container } = render(
+            <DroppableTable
+                table={table}
+                inEdit={true}
+                editTable={{}}
+                setEditTable={setEditTable}
+                setOrders={setOrders}
+            />
+        );
+        
         const tableElement = screen.getByText("1");
         await userEvent.click(tableElement);
+        expect(setEditTable).toHaveBeenCalledWith(table);
+        expect(container.firstChild).toHaveClass("border-kitchen-button-orange");
+    });
+
+    test("clicking table updates orders", async () => {
+        const setEditTable = jest.fn();
+        const setOrders = jest.fn();
+        const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
+        render(
+            <DroppableTable
+                table={table}
+                inEdit={false}
+                editTable={{}}
+                setEditTable={setEditTable}
+                setOrders={setOrders}
+            />
+        );
         
-        expect(console.log).toHaveBeenCalledWith("Table 1 clicked");
+        const tableElement = screen.getByText("1");
+        await userEvent.click(tableElement);
+
+        expect(setOrders).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    test("renders correct time", () => {
+        const table = { id: 1, type: "rectangle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "15:30" };
+        render(
+            <DroppableTable
+                table={table}
+                inEdit={false}
+                editTable={{}}
+                setEditTable={() => {}}
+                setOrders={() => {}}
+            />
+        );
+        expect(screen.getByText("15:30")).toBeInTheDocument();
     });
 });

--- a/src/__tests__/Components/TableView/TablesPanel.test.js
+++ b/src/__tests__/Components/TableView/TablesPanel.test.js
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import TablesPanel from "../../../Components/TablesView/TablesPanel";
+import React from "react";
+
+describe('PlatesButton', () => {
+    let setEditTableMock;
+    let editTable;
+
+    beforeEach(() => {
+        setEditTableMock = jest.fn();
+        editTable = { plates: 3 };
+    });
+
+    test('renders PlatesButton', () => {
+        render(<TablesPanel orders={[{ nb: 1 }]} editTable={editTable} setEditTable={setEditTableMock} setBoard={jest.fn()} />);
+        
+        expect(screen.getByText(/Couverts : 3/i)).toBeInTheDocument();
+    });
+
+    test('"+" button click', () => {
+        render(<TablesPanel orders={[{ nb: 1 }]} editTable={editTable} setEditTable={setEditTableMock} setBoard={jest.fn()} />);
+        
+        fireEvent.click(screen.getByText('+'));
+
+        expect(setEditTableMock).toHaveBeenCalledWith(expect.any(Function)); 
+        expect(setEditTableMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('"-" button click', () => {
+        render(<TablesPanel orders={[{ nb: 1 }]} editTable={editTable} setEditTable={setEditTableMock} setBoard={jest.fn()} />);
+        
+        fireEvent.click(screen.getByText('-'));
+
+        expect(setEditTableMock).toHaveBeenCalledWith(expect.any(Function)); 
+        expect(setEditTableMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not decrement below zero', () => {
+        editTable.plates = 0;
+        render(<TablesPanel orders={[{ nb: 1 }]} editTable={editTable} setEditTable={setEditTableMock} setBoard={jest.fn()} />);
+        
+        fireEvent.click(screen.getByText('-'));
+
+        expect(setEditTableMock).toHaveBeenCalledWith(expect.any(Function)); 
+        expect(setEditTableMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('EditPanel', () => {
+    let setEditTableMock;
+    let editTable;
+
+    beforeEach(() => {
+        setEditTableMock = jest.fn();
+        editTable = { id: '1', plates: 3 };
+    });
+
+    test('renders EditPanel', () => {
+        render(<TablesPanel orders={[{ nb: 1 }]} editTable={editTable} setEditTable={setEditTableMock} setBoard={jest.fn()} />);
+        
+        expect(screen.getByText('Table 1')).toBeInTheDocument();
+    });
+});
+
+describe('TablesPanel', () => {
+    let setEditTableMock;
+    let setBoardMock;
+    let orders;
+    let editTable;
+
+    beforeEach(() => {
+        setEditTableMock = jest.fn();
+        setBoardMock = jest.fn();
+        orders = [{ nb: 1 }];
+        editTable = { id: 1, plates: 3, left: 1, top: 1 };
+    });
+
+    test('renders TablesPanel', () => {
+        render(<TablesPanel orders={orders} editTable={editTable} setEditTable={setEditTableMock} setBoard={setBoardMock} />);
+        
+        expect(screen.getByText('Table 1')).toBeInTheDocument();
+    });
+
+    test('EditPanel when table is being edited', () => {
+        render(<TablesPanel orders={orders} editTable={editTable} setEditTable={setEditTableMock} setBoard={setBoardMock} />);
+        
+        fireEvent.click(screen.getByText('Table 1'));
+
+        expect(screen.getByText('Couverts : 3')).toBeInTheDocument();
+    });
+
+    test('calls setBoard', () => {
+        render(<TablesPanel orders={orders} editTable={editTable} setEditTable={setEditTableMock} setBoard={setBoardMock} />);
+
+        act(() => {
+            setEditTableMock({ id: 2, plates: 5, left: 1, top: 1 });
+        });
+
+        expect(setBoardMock).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Describe your changes

Added an edit mode to the tables when clicked on.
Known issue : Table name size

## How to test the feature

Got to the table page. Place tables, then while in edit mode (grey tables) click on one of them. Table will be orange, and you change both the name of the table and the number of plates.

## Issue ticket number and link

#88 

## Checklist before requesting a review
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
