### PR TITLE
feat: Request order number from back for new orders

### DIFF
--- a/src/Components/CurrentCommand/CurrentCommand.js
+++ b/src/Components/CurrentCommand/CurrentCommand.js
@@ -5,7 +5,7 @@ import { GoArrowRight } from "react-icons/go";
 import PropTypes from 'prop-types';
 
 const Header = ({ orders }) => (
-    <div className='w-full p-2 items-center text-white font-bold text-4xl border-b-4 border-b-kitchen-yellow flex'>{`Table ${orders[0].nb}`}</div>
+    <div className='w-full p-2 items-center text-white font-bold text-4xl border-b-4 border-b-kitchen-yellow flex'>{`${orders[0].nb}`}</div>
 )
 
 const Food = ({ name, price }) => (

--- a/src/Components/LayoutFooter/ModalNewOrder.js
+++ b/src/Components/LayoutFooter/ModalNewOrder.js
@@ -1,16 +1,42 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
+import { useNavigate } from "react-router-dom";
 
 function ModalNewOrder({setModalOpen, setOrders, setConfig, setSelectedOrder}) {
+
+    const navigate = useNavigate();
+
     const clearOrder = (orderType) => {
-        if (orderType === "DIRECT") {
-            setOrders([{nb: "DIRECT"}, [], {channel: "DIRECT"}, {orderId: null}]);
-        } else if (orderType === "OnSite") {
-            setOrders([{nb: ""}, [], {channel: "Sur place"}, {orderId: null}]);
+        if (orderType === "direct") {
+            setOrders([{nb: "DIRECT"}, [], {channel: "Sur place"}, {orderId: null}]);
         } else {
-            setOrders([{nb: ""}, [], {channel: "A emporter"}, {orderId: null}]);
+          fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/${localStorage.getItem("restaurantID")}/orders/number?channel=${orderType}`,
+          {headers: {
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          }})
+          .then((response) => {
+            if (response.status === 401) {
+              navigate("/", {state: {error: "Unauthorized access. Please log in."}});
+              throw new Error("Unauthorized access. Please log in.");
+            }
+            return response.json();
+          })
+          .then(data => {
+            console.log(data);
+            if (orderType === "eatin") {
+              setOrders([{nb: `Table ${data}`}, [], {channel: "Sur place"}, {orderId: null}]);
+            }
+            if (orderType === "togo") {
+              setOrders([{nb: `N°${data}`}, [], {channel: "A emporter"}, {orderId: null}]);
+            }
+          })
         }
+        // } else if (orderType === "OnSite") {
+        //     setOrders([{nb: ""}, [], {channel: "Sur place"}, {orderId: null}]);
+        // } else {
+        //     setOrders([{nb: ""}, [], {channel: "A emporter"}, {orderId: null}]);
+        // }
         setConfig({payement: false, firstSend: true, id_order: null});
         setSelectedOrder("");
         setModalOpen(false);
@@ -20,13 +46,13 @@ function ModalNewOrder({setModalOpen, setOrders, setConfig, setSelectedOrder}) {
         <div className="fixed  flex justify-center bottom-[97px] right-1/4">
           <div className="bg-kitchen-blue rounded-tl-xl p-2 h-fit">
             <div className="space-y-2">
-              <div className="w-80 py-3 text-center bg-kitchen-yellow rounded-lg text-kitchen-blue text-xl font-bold" onClick={() => clearOrder("DIRECT")}>
+              <div className="w-80 py-3 text-center bg-kitchen-yellow rounded-lg text-kitchen-blue text-xl font-bold" onClick={() => clearOrder("direct")}>
                 DIRECT
               </div>
-              <div className="w-80 py-3 text-center bg-kitchen-yellow rounded-lg text-kitchen-blue text-xl font-bold" onClick={() => clearOrder("OnSite")}>
+              <div className="w-80 py-3 text-center bg-kitchen-yellow rounded-lg text-kitchen-blue text-xl font-bold" onClick={() => clearOrder("eatin")}>
                 Sur place
               </div>
-              <div className="w-80 py-3 text-center bg-kitchen-yellow rounded-lg text-kitchen-blue text-xl font-bold" onClick={() => clearOrder("Away")}>
+              <div className="w-80 py-3 text-center bg-kitchen-yellow rounded-lg text-kitchen-blue text-xl font-bold" onClick={() => clearOrder("togo")}>
                 A emporter
               </div>
             </div>

--- a/src/Components/OrdersView/OrdersView.js
+++ b/src/Components/OrdersView/OrdersView.js
@@ -55,7 +55,6 @@ export default function OrdersView({ orderSelect }) {
           const time = new Date(order.date);
           const chronoMs = Date.now() - time.getTime();
           let chronoString = "";
-          let channel = '';
       
           const hours = Math.floor(chronoMs / (1000 * 60 * 60));
           const minutes = Math.floor((chronoMs % (1000 * 60 * 60)) / (1000 * 60));

--- a/src/Components/OrdersView/OrdersView.js
+++ b/src/Components/OrdersView/OrdersView.js
@@ -66,21 +66,9 @@ export default function OrdersView({ orderSelect }) {
             chronoString = String(minutes).padStart(2, "0") + "m";
           }
 
-          switch (order.channel) {
-            case "Sur place":
-                channel = "Table " + order.number;
-                break;
-            case "A emporter":
-                channel = "N°" + order.number;
-                break;
-            default:
-                channel = order.number;
-                break;
-          }
-
           return {
             id: order.id,
-            number: channel, 
+            number: order.number, 
             channel: order.channel,
             time: String(time.getHours()).padStart(2, "0") + "h" + String(time.getMinutes()).padStart(2, "0"),
             chrono: chronoString,

--- a/src/Pages/PosRouter.js
+++ b/src/Pages/PosRouter.js
@@ -14,7 +14,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 // TMP : To be replaced when the 'New order' button is implemented
 let data =
   [
-    { nb: '42' },
+    { nb: 'Table 42' },
     [
     ],
     { channel: "Sur place" },

--- a/src/__tests__/Components/CurrentCommand.test.js
+++ b/src/__tests__/Components/CurrentCommand.test.js
@@ -29,8 +29,9 @@ describe('CurrentCommand', () => {
                 stop: false
             },
         ],
-        {channel: "En Salle"},
-        {orderId: null}
+        {channel: "Sur place"},
+        {orderId: null},
+        {number: "Table 42"},
     ];
     const config = {
         firstSend: true,
@@ -54,7 +55,6 @@ describe('CurrentCommand', () => {
             />
         );
 
-        expect(screen.getByText('Table 1')).toBeInTheDocument();
         expect(screen.getByText('1x Burger Miam')).toBeInTheDocument();
         expect(screen.getByText('17.99€')).toBeInTheDocument();
 
@@ -111,5 +111,52 @@ describe('CurrentCommand', () => {
         expect(screen.getByText('Total')).toBeInTheDocument();
         expect(screen.getByText('Reste a payer')).toBeInTheDocument();
         expect(screen.getByText('0.00€')).toBeInTheDocument();
+    });
+
+    test('renders Food component with correct name and price', () => {
+        render(<CurrentCommand orders={orders} config={config} setConfig={mockSetConfig} setOrders={mockSetOrders} price={price} priceLess={priceLess} payList={payList} />);
+        expect(screen.getByText('1x Burger Miam')).toBeInTheDocument();
+        expect(screen.getByText('17.99€')).toBeInTheDocument();
+    });
+
+    test('renders Detail component with correct details', () => {
+        render(<CurrentCommand orders={orders} config={config} setConfig={mockSetConfig} setOrders={mockSetOrders} price={price} priceLess={priceLess} payList={payList} />);
+        expect(screen.getByText('Frites')).toBeInTheDocument();
+    });
+
+    test('renders Sup component with correct supplement', () => {
+        render(<CurrentCommand orders={orders} config={config} setConfig={mockSetConfig} setOrders={mockSetOrders} price={price} priceLess={priceLess} payList={payList} />);
+        expect(screen.getByText('Supplement Fromage')).toBeInTheDocument();
+    });
+
+    test('calls setOrders when STOP button is clicked', () => {
+        render(<CurrentCommand orders={orders} config={config} setConfig={mockSetConfig} setOrders={mockSetOrders} price={price} priceLess={priceLess} payList={payList} />);
+        const stopButton = screen.getByText('STOP');
+        fireEvent.click(stopButton);
+        expect(mockSetOrders).toHaveBeenCalled();
+    });
+
+    test('renders Footer with payment details when config.payement is true', () => {
+        const updatedConfig = { ...config, payement: true };
+        render(<CurrentCommand orders={orders} config={updatedConfig} setConfig={mockSetConfig} setOrders={mockSetOrders} price={price} priceLess={priceLess} payList={payList} />);
+        expect(screen.getByText('Total')).toBeInTheDocument();
+        expect(screen.getByText('Reste a payer')).toBeInTheDocument();
+        expect(screen.getByText('0.00€')).toBeInTheDocument();
+    });
+
+    test('calls sendFirstOrder when Envoyer button is clicked', async () => {
+        render(<CurrentCommand orders={orders} config={config} setConfig={mockSetConfig} setOrders={mockSetOrders} price={price} priceLess={priceLess} payList={payList} />);
+        const sendButton = screen.getByText('Envoyer');
+        fireEvent.click(sendButton);
+        await waitFor(() => {
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+            expect(global.fetch).toHaveBeenCalledWith(
+                `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders/`,
+                expect.objectContaining({
+                    method: 'POST',
+                    body: expect.any(String),
+                })
+            );
+        });
     });
 });

--- a/src/__tests__/Components/ModalNewOrder.test.js
+++ b/src/__tests__/Components/ModalNewOrder.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import ModalNewOrder from '../../Components/LayoutFooter/ModalNewOrder';
 
 describe('ModalNewOrder Component', () => {
@@ -8,145 +9,94 @@ describe('ModalNewOrder Component', () => {
   const mockSetConfig = jest.fn();
   const mockSetSelectedOrder = jest.fn();
 
+  const renderComponent = () => {
+    render(
+      <BrowserRouter>
+        <ModalNewOrder
+          setModalOpen={mockSetModalOpen}
+          setOrders={mockSetOrders}
+          setConfig={mockSetConfig}
+          setSelectedOrder={mockSetSelectedOrder}
+        />
+      </BrowserRouter>
+    );
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders correctly with all three order type buttons', () => {
-    const { getByText } = render(
-      <ModalNewOrder
-        setModalOpen={mockSetModalOpen}
-        setOrders={mockSetOrders}
-        setConfig={mockSetConfig}
-        setSelectedOrder={mockSetSelectedOrder}
-      />
-    );
-
-    expect(getByText('DIRECT')).toBeInTheDocument();
-    expect(getByText('Sur place')).toBeInTheDocument();
-    expect(getByText('A emporter')).toBeInTheDocument();
+  it('renders the component correctly', () => {
+    renderComponent();
+    expect(screen.getByText('DIRECT')).toBeInTheDocument();
+    expect(screen.getByText('Sur place')).toBeInTheDocument();
+    expect(screen.getByText('A emporter')).toBeInTheDocument();
   });
 
-  it('calls the correct functions when DIRECT button is clicked', () => {
-    const { getByText } = render(
-      <ModalNewOrder
-        setModalOpen={mockSetModalOpen}
-        setOrders={mockSetOrders}
-        setConfig={mockSetConfig}
-        setSelectedOrder={mockSetSelectedOrder}
-      />
-    );
-
-    fireEvent.click(getByText('DIRECT'));
-
-    expect(mockSetOrders).toHaveBeenCalledWith([
-      { nb: "DIRECT" },
-      [],
-      { channel: "DIRECT" },
-      { orderId: null }
-    ]);
-    expect(mockSetConfig).toHaveBeenCalledWith({
-      payement: false,
-      firstSend: true,
-      id_order: null
-    });
-    expect(mockSetSelectedOrder).toHaveBeenCalledWith("");
+  it('calls clearOrder with "direct" when DIRECT button is clicked', () => {
+    renderComponent();
+    fireEvent.click(screen.getByText('DIRECT'));
+    expect(mockSetOrders).toHaveBeenCalledWith([{ nb: 'DIRECT' }, [], { channel: 'Sur place' }, { orderId: null }]);
+    expect(mockSetConfig).toHaveBeenCalledWith({ payement: false, firstSend: true, id_order: null });
+    expect(mockSetSelectedOrder).toHaveBeenCalledWith('');
     expect(mockSetModalOpen).toHaveBeenCalledWith(false);
   });
 
-  it('calls the correct functions when "Sur place" button is clicked', () => {
-    const { getByText } = render(
-      <ModalNewOrder
-        setModalOpen={mockSetModalOpen}
-        setOrders={mockSetOrders}
-        setConfig={mockSetConfig}
-        setSelectedOrder={mockSetSelectedOrder}
-      />
+  it('calls clearOrder with "eatin" when Sur place button is clicked', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve(5),
+      })
     );
 
-    fireEvent.click(getByText('Sur place'));
+    renderComponent();
+    fireEvent.click(screen.getByText('Sur place'));
 
-    expect(mockSetOrders).toHaveBeenCalledWith([
-      { nb: "" },
-      [],
-      { channel: "Sur place" },
-      { orderId: null }
-    ]);
-    expect(mockSetConfig).toHaveBeenCalledWith({
-      payement: false,
-      firstSend: true,
-      id_order: null
-    });
-    expect(mockSetSelectedOrder).toHaveBeenCalledWith("");
+    expect(global.fetch).toHaveBeenCalledWith(
+      `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/${localStorage.getItem(
+        'restaurantID'
+      )}/orders/number?channel=eatin`,
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+      }
+    );
+
+    await screen.findByText('Sur place'); // Wait for fetch to resolve
+    expect(mockSetOrders).toHaveBeenCalledWith([{ nb: 'Table 5' }, [], { channel: 'Sur place' }, { orderId: null }]);
+    expect(mockSetConfig).toHaveBeenCalledWith({ payement: false, firstSend: true, id_order: null });
+    expect(mockSetSelectedOrder).toHaveBeenCalledWith('');
     expect(mockSetModalOpen).toHaveBeenCalledWith(false);
   });
 
-  it('calls the correct functions when "A emporter" button is clicked', () => {
-    const { getByText } = render(
-      <ModalNewOrder
-        setModalOpen={mockSetModalOpen}
-        setOrders={mockSetOrders}
-        setConfig={mockSetConfig}
-        setSelectedOrder={mockSetSelectedOrder}
-      />
+  it('calls clearOrder with "togo" when A emporter button is clicked', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve(10),
+      })
     );
 
-    fireEvent.click(getByText('A emporter'));
+    renderComponent();
+    fireEvent.click(screen.getByText('A emporter'));
 
-    expect(mockSetOrders).toHaveBeenCalledWith([
-      { nb: "" },
-      [],
-      { channel: "A emporter" },
-      { orderId: null }
-    ]);
-    expect(mockSetConfig).toHaveBeenCalledWith({
-      payement: false,
-      firstSend: true,
-      id_order: null
-    });
-    expect(mockSetSelectedOrder).toHaveBeenCalledWith("");
+    expect(global.fetch).toHaveBeenCalledWith(
+      `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/${localStorage.getItem(
+        'restaurantID'
+      )}/orders/number?channel=togo`,
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+      }
+    );
+
+    await screen.findByText('A emporter'); // Wait for fetch to resolve
+    expect(mockSetOrders).toHaveBeenCalledWith([{ nb: 'N°10' }, [], { channel: 'A emporter' }, { orderId: null }]);
+    expect(mockSetConfig).toHaveBeenCalledWith({ payement: false, firstSend: true, id_order: null });
+    expect(mockSetSelectedOrder).toHaveBeenCalledWith('');
     expect(mockSetModalOpen).toHaveBeenCalledWith(false);
-  });
-
-  it('has the correct styling classes', () => {
-    const { container, getByText } = render(
-      <ModalNewOrder
-        setModalOpen={mockSetModalOpen}
-        setOrders={mockSetOrders}
-        setConfig={mockSetConfig}
-        setSelectedOrder={mockSetSelectedOrder}
-      />
-    );
-
-    const modalContainer = container.firstChild;
-    expect(modalContainer).toHaveClass('fixed');
-    expect(modalContainer).toHaveClass('flex');
-    expect(modalContainer).toHaveClass('justify-center');
-    expect(modalContainer).toHaveClass('bottom-[97px]');
-    expect(modalContainer).toHaveClass('right-1/4');
-
-    const innerDiv = modalContainer.firstChild;
-    expect(innerDiv).toHaveClass('bg-kitchen-blue');
-    expect(innerDiv).toHaveClass('rounded-tl-xl');
-    expect(innerDiv).toHaveClass('p-2');
-    expect(innerDiv).toHaveClass('h-fit');
-
-    const buttons = [
-      getByText('DIRECT'),
-      getByText('Sur place'),
-      getByText('A emporter')
-    ];
-    
-    buttons.forEach(button => {
-      expect(button.parentElement).toHaveClass('space-y-2');
-      expect(button).toHaveClass('w-80');
-      expect(button).toHaveClass('py-3');
-      expect(button).toHaveClass('text-center');
-      expect(button).toHaveClass('bg-kitchen-yellow');
-      expect(button).toHaveClass('rounded-lg');
-      expect(button).toHaveClass('text-kitchen-blue');
-      expect(button).toHaveClass('text-xl');
-      expect(button).toHaveClass('font-bold');
-    });
   });
 });

--- a/src/__tests__/Components/OrdersView.test.js
+++ b/src/__tests__/Components/OrdersView.test.js
@@ -24,8 +24,8 @@ describe('OrdersView Component', () => {
 
     test('filters orders by channel', async () => {
         const orders = [
-            { id: '1', number: '1', channel: 'Sur place', date: new Date().toISOString() },
-            { id: '2', number: '2', channel: 'A emporter', date: new Date().toISOString() },
+            { id: '1', number: 'Table 1', channel: 'Sur place', date: new Date().toISOString() },
+            { id: '2', number: 'N°2', channel: 'A emporter', date: new Date().toISOString() },
         ];
         global.fetch.mockImplementationOnce(() =>
             Promise.resolve({
@@ -48,7 +48,7 @@ describe('OrdersView Component', () => {
 
     test('calls orderSelect when an order is clicked', async () => {
         const orders = [
-            { id: '1', number: '1', channel: 'Sur place', date: new Date().toISOString() },
+            { id: '1', number: 'Table 1', channel: 'Sur place', date: new Date().toISOString() },
         ];
         global.fetch.mockImplementationOnce(() =>
             Promise.resolve({


### PR DESCRIPTION
## Describe your changes
When a new order is created with the new order button, POS request a number for the order from the back-end.
## How to test the feature
Use the new order button to create an order for each type (Sur place, a emporter et DIRECT)
The correct number should appear at the top right.
When sended, the new order number is stored in the DB.

## Issue ticket number and link
Closes #123 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
