### PR TITLE
feat: Added the fuse and separate feature of the table page

### DIFF
--- a/src/Components/TablesView/DroppableTable.js
+++ b/src/Components/TablesView/DroppableTable.js
@@ -6,16 +6,39 @@ import PropTypes from "prop-types";
  * @param {Object} table - table object containing the main informations, such as table name, number of plates, positions...
  * @param {boolean} inEdit - boolean used to change style and behaviour of the tables.
  * @param {Object} editTable Object used to know which table is currently being edited
+ * @param {Object} inFuse Object used to know which table is currently being selected to fuse, and which are already fused
+ * @param {Function} setInFuse state function used to check the type of fuse, and update the arrays containing fused tables and selected tables
  * @param {Function} setEditTable state function used to update the table in edit
  * @param {Function} setOrders state function used to update the current order
  * @returns {JSX.Element} The rendered DroppableTable component.
  */
-function DroppableTable({table, inEdit, editTable, setEditTable, setOrders}) {
+function DroppableTable({table, inEdit, editTable, inFuse, setInFuse, setEditTable, setOrders}) {
 
     const [border, setBorder] = useState("border-black")
+    const [fuseBorder, setFuseBorder] = useState("border-kitchen-green")
 
     const onTableClick = () => {
-        if (inEdit) {
+        if (inFuse.type !== "None") {
+            setInFuse((fused) => {
+                const filteredList = fused.fusedList.filter((t) => t.left !== table.left || t.top !== table.top);
+                if (filteredList.length < fused.fusedList.length) {
+                    if (table.time === "00:00") {
+                        setFuseBorder("border-kitchen-green")
+                    } else {
+                        setFuseBorder("border-kitchen-yellow")
+                    }
+                    return {...fused, fusedList: filteredList, sepList: [...fused.sepList]};
+                }
+                const newList = [...filteredList, table];
+                setFuseBorder("border-kitchen-button-orange")
+                if (inFuse.type === "Fuse" && newList.length > 2) {
+                    newList.shift();
+                } else if (inFuse.type === "Sep" && newList.length > 1) {
+                    newList.shift();
+                }
+                return {...fused, fusedList: newList, sepList: [...fused.sepList]};
+              });
+        } else if (inEdit) {
             setBorder("border-kitchen-button-orange")
             setEditTable(table)
         } else {
@@ -24,13 +47,23 @@ function DroppableTable({table, inEdit, editTable, setEditTable, setOrders}) {
     };
 
     useEffect(() => {
+        if (!inFuse.fusedList.includes(table)) {
+            if (table.time === "00:00") {
+                setFuseBorder("border-kitchen-green")
+            } else {
+                setFuseBorder("border-kitchen-yellow")
+            }
+        }
+    }, [inFuse, table])
+
+    useEffect(() => {
         if (table.top !== editTable.top && table.left !== editTable.left) {
             setBorder("border-black")
         }
     }, [editTable, table])
 
     return (
-        <div onClick={() => onTableClick()} name={table.id} className={`${table.type === "circle" ? "rounded-full" : ""} border-4 absolute col-span-1 grid grid-flow-row ${inEdit === true ? `bg-grey-bg ${border} grid-rows-2` : table.time === "00:00" ? "bg-kitchen-green border-kitchen-green grid-rows-3" : "bg-kitchen-yellow border-kitchen-yellow grid-rows-3"} justify-center justify-items-center`} style={{width: table.w, height: table.h, top: table.top, left: table.left}}>   
+        <div onClick={() => onTableClick()} name={table.id} className={`${table.type === "circle" ? "rounded-full" : ""} border-4 absolute col-span-1 grid grid-flow-row ${inEdit === true ? `bg-grey-bg ${border} grid-rows-2` : table.time === "00:00" ? `bg-kitchen-green ${fuseBorder} grid-rows-3` : `bg-kitchen-yellow ${fuseBorder} grid-rows-3`} justify-center justify-items-center`} style={{width: table.w, height: table.h, top: table.top, left: table.left}}>   
             <div className={`${table.type === "circle" ? (table.id.length > 5 ? "text-xl" : "text-2xl") : (table.id.length > 5 ? "text-2xl" : "text-3xl")} row-span-1 self-center font-bold`}>{table.id}</div>
             <div className={`${table.type === "circle" ? "text-xl" : "text-2xl"} row-span-1 self-center`}>{table.plates} {table.type === "rectangle" ? "couverts" : "couv."}</div>
             {inEdit === false ? table.time === "00:00" ?
@@ -45,6 +78,8 @@ DroppableTable.propTypes = {
     table: PropTypes.object.isRequired,
     inEdit: PropTypes.bool.isRequired,
     editTable: PropTypes.object.isRequired,
+    inFuse: PropTypes.object.isRequired,
+    setInFuse: PropTypes.func.isRequired,
     setEditTable: PropTypes.func.isRequired,
     setOrders: PropTypes.func.isRequired,
 }

--- a/src/Components/TablesView/TablesFooter.js
+++ b/src/Components/TablesView/TablesFooter.js
@@ -7,34 +7,131 @@ import Tables from "./Tables";
 /**
  * TablesFooter component rendering the table pages footer buttons.
  * @param {function} setInEdit - useState functions used to change the behaviour of tables.
+ * @param {Object} inFuse Object used to know which table is currently being selected to fuse, and which are already fused
+ * @param {Function} setInFuse state function used to check the type of fuse, and update the arrays containing fused tables and selected tables
+ * @param {Function} setBoard state function used to update the tables board
  * @returns {JSX.Element} The rendered TablesFooter component.
  */
-function TablesFooter({setInEdit}) {
+function TablesFooter({setInEdit, inFuse, setInFuse, setBoard}) {
 
     const [activeButton, setActiveButton] = useState("None");
 
     useEffect(() => {
         if (activeButton === "Edit") {
+            setInFuse((fused) => {return({type: "None", fusedList: [...fused.fusedList], sepList: [...fused.sepList]})})
             setInEdit(true)
+        } else if (activeButton === "Fuse") {
+            setInFuse((fused) => {return({type: "Fuse", fusedList: [...fused.fusedList], sepList: [...fused.sepList]})})
+            setInEdit(false)
+        } else if (activeButton === "Sep") {
+            setInFuse((fused) => {return({type: "Sep", fusedList: [...fused.fusedList], sepList: [...fused.sepList]})})
+            setInEdit(false)
         } else {
+            setInFuse((fused) => {return({type: "None", fusedList: [], sepList: [...fused.sepList]})})
             setInEdit(false)
         }
-    }, [activeButton, setInEdit]);
+    }, [activeButton, setInEdit, setInFuse]);
+
+    const checkTablePos = (table1, table2) => {
+        let diffTop = Math.abs(table2.top - table1.top);
+        let diffLeft = Math.abs(table2.left - table1.left);
+        if (diffTop > diffLeft) {
+            return true;
+            //fusion vers le bas
+        }
+        return false;
+        //fusion vers le haut
+    }
+
+    const onFuseAdd = () => {
+        if (inFuse.fusedList.length > 1) {
+            setBoard((prevBoard) => {
+                const [table1, table2] = inFuse.fusedList;
+                return prevBoard.reduce((newBoard, table) => {
+                    const table1Check = table.left === table1.left && table.top === table1.top;
+                    const table2Check = table.left === table2.left && table.top === table2.top;
+                    if (table1Check) {
+                        const size = checkTablePos(table1, table2);
+                        const updatedTable = {
+                            ...table,
+                            plates: table.plates + table2.plates,
+                            h: table.h + (size ? table2.h : 0),
+                            w: table.w + (!size ? table2.w : 0),
+                        };
+                        newBoard.push(updatedTable);
+                    } else if (!table2Check) {
+                        newBoard.push(table);
+                    }
+                    return newBoard;
+                }, []);
+            });
+            setInFuse((prevFuse) => {
+                return {
+                    ...prevFuse,
+                    fusedList: [],
+                    sepList: [...prevFuse.sepList, ...prevFuse.fusedList],
+                };
+            });
+        }
+    };
+
+    const onSepAdd = () => {
+        setBoard((prevBoard) => {
+            if (inFuse.fusedList.length > 0) {
+                const [fusedTable] = inFuse.fusedList;
+
+                const index = inFuse.sepList.findIndex(
+                    (t) => t.left === fusedTable.left && t.top === fusedTable.top
+                );
+                if (index === -1 || index + 1 >= inFuse.sepList.length) return prevBoard;
+
+                const sepTable1 = inFuse.sepList[index];
+                const sepTable2 = inFuse.sepList[index + 1];
+
+                const updatedBoard = prevBoard.map((table) => {
+                    const isFused = table.left === fusedTable.left && table.top === fusedTable.top;
+                    return isFused ? sepTable1 : table;
+                });
+                return [...updatedBoard, sepTable2];
+            }
+        });
+        setInFuse((prevFuse) => {
+            const [fusedTable] = prevFuse.fusedList;
+
+            const index = prevFuse.sepList.findIndex(
+              (t) => t.left === fusedTable.left && t.top === fusedTable.top
+            );
+
+            if (index === -1 || index + 1 >= prevFuse.sepList.length) return prevFuse;
+
+            const newSepList = [...prevFuse.sepList];
+            newSepList.splice(index, 2);
+            return {
+                ...prevFuse,
+                fusedList: [],
+                sepList: newSepList,
+            };
+        });
+    };
+
+    const onDel = () => {
+        setActiveButton("None")
+    };
 
     return (
         <div className="row-span-1 bg-kitchen-blue shadow-button grid grid-flow-col grid-cols-12">
             <FooterButton url="fuse.png" type="Fuse" activeButton={activeButton} setActiveButton={setActiveButton} />
             {activeButton === "Fuse" &&
                 <div className="col-span-4 grid grid-flow-col grid-cols-2 justify-center justify-items-center">
-                    <div id="fuse-add" className="col-span-1 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-green self-center rounded-full">Fusionner</div>
-                    <div id="fuse-del" className="col-span-1 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-red self-center rounded-full">Annuler</div>
+                    <div onClick={() => onFuseAdd()} id="fuse-add" className="col-span-1 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-green self-center rounded-full">Fusionner</div>
+                    <div onClick={() => onDel()} id="fuse-del" className="col-span-1 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-red self-center rounded-full">Annuler</div>
                 </div>
             }
             <FooterButton url="sep.png" type="Sep" activeButton={activeButton} setActiveButton={setActiveButton} />
             {activeButton === "Sep" &&
                 <div className="col-span-9 grid grid-flow-col grid-cols-9 justify-center justify-items-center">
-                    <div id="sep-add" className="col-span-2 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-green self-center rounded-full">Séparer</div>
-                    <div id="sep-del" className="col-span-2 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-red self-center rounded-full">Annuler</div>
+                    <div onClick={() => onSepAdd()} id="sep-add" className="col-span-2 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-green self-center rounded-full">Séparer</div>
+                    <div onClick={() => onDel()} id="sep-del" className="col-span-2 flex items-center justify-center w-3/4 h-2/4 font-bold text-3xl text-white bg-kitchen-button-red self-center rounded-full">Annuler</div>
                     <div id="blank" className="col-span-5" />
                 </div>
             }
@@ -51,7 +148,10 @@ function TablesFooter({setInEdit}) {
 }
 
 TablesFooter.propTypes = {
-    setInEdit: PropTypes.func.isRequired
+    setInEdit: PropTypes.func.isRequired,
+    inFuse: PropTypes.object.isRequired,
+    setInFuse: PropTypes.func.isRequired,
+    setBoard: PropTypes.func.isRequired,
 }
 
 export default TablesFooter;

--- a/src/Components/TablesView/TablesView.js
+++ b/src/Components/TablesView/TablesView.js
@@ -9,9 +9,9 @@ import { ItemTypes } from "./Constants";
 import DroppableTable from "./DroppableTable";
 
 const TableList = [
-    {type: "square", plates: 2, w: 100, h: 100, time: "00:00"},
-    {type: "circle", plates: 2, w: 100, h: 100, time: "00:00"},
-    {type: "rectangle", plates: 4, w: 200, h: 100, time: "00:00"}
+    {type: "square", plates: 2, w: 100, h: 100, time: "00:00", fused: false},
+    {type: "circle", plates: 2, w: 100, h: 100, time: "00:00", fused: false},
+    {type: "rectangle", plates: 4, w: 200, h: 100, time: "00:00", fused: false}
 ]
 
 /**
@@ -25,6 +25,7 @@ const TableList = [
 export default function TablesView({ orders, setOrders, board, setBoard }) {
 
     const [inEdit, setInEdit] = useState(false);
+    const [inFuse, setInFuse] = useState({type: "None", fusedList: [], sepList: []});
     const [editTable, setEditTable] = useState({id: -1, plates: 0});
 
     const drop = useDrop(() => ({
@@ -92,7 +93,7 @@ export default function TablesView({ orders, setOrders, board, setBoard }) {
     }, [inEdit]);
 
     const boardElem = board.map((table) => (
-        <DroppableTable key={table.id} table={table} inEdit={inEdit} editTable={editTable} setEditTable={setEditTable} setOrders={setOrders} />
+        <DroppableTable key={table.id} table={table} inEdit={inEdit} editTable={editTable} inFuse={inFuse} setInFuse={setInFuse} setEditTable={setEditTable} setOrders={setOrders} />
     ));
 
     return (
@@ -101,7 +102,7 @@ export default function TablesView({ orders, setOrders, board, setBoard }) {
                 <div id="drop-area" ref={drop} className="row-span-9">
                     {boardElem}
                 </div>
-                <TablesFooter setInEdit={setInEdit} />
+                <TablesFooter setInEdit={setInEdit} inFuse={inFuse} setInFuse={setInFuse} setBoard={setBoard} />
             </div>
             <TablesPanel orders={orders} editTable={editTable} setEditTable={setEditTable} setBoard={setBoard} />
         </div>

--- a/src/__tests__/Components/TableView/DroppableTable.test.js
+++ b/src/__tests__/Components/TableView/DroppableTable.test.js
@@ -4,74 +4,121 @@ import userEvent from "@testing-library/user-event";
 import DroppableTable from "../../../Components/TablesView/DroppableTable";
 
 describe("DroppableTable Component", () => {
-    test("renders DroppableTable", () => {
-        const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
-        render(<DroppableTable table={table} inEdit={false} editTable={{}} setEditTable={() => {}} setOrders={() => {}} />);
-        
+    const baseTable = {id: "1", type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00"};
+
+    test("renders DroppableTable in non-edit mode", () => {
+        render(
+            <DroppableTable
+                table={baseTable}
+                inEdit={false}
+                editTable={{}}
+                inFuse={{type: "None", fusedList: [], sepList: []}}
+                setInFuse={() => {}}
+                setEditTable={() => {}}
+                setOrders={() => {}}
+            />
+        );
+
         expect(screen.getByText("1")).toBeInTheDocument();
         expect(screen.getByText("2 couv.")).toBeInTheDocument();
         expect(screen.getByText("Dispo.")).toBeInTheDocument();
     });
 
-    test("renders DroppableTable edit mode", () => {
-        const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
-        render(<DroppableTable table={table} inEdit={true} editTable={{}} setEditTable={() => {}} setOrders={() => {}} />);
-        
+    test("renders DroppableTable in edit mode", () => {
+        render(
+            <DroppableTable
+                table={baseTable}
+                inEdit={true}
+                editTable={{}}
+                inFuse={{type: "None", fusedList: [], sepList: []}}
+                setInFuse={() => {}}
+                setEditTable={() => {}}
+                setOrders={() => {}}
+            />
+        );
+
         expect(screen.getByText("1")).toBeInTheDocument();
         expect(screen.getByText("2 couv.")).toBeInTheDocument();
     });
 
-    test("clicking table updates editTable", async () => {
+    test("clicking table in edit mode sets editTable and changes border", async () => {
         const setEditTable = jest.fn();
-        const setOrders = jest.fn();
-        const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
         const { container } = render(
             <DroppableTable
-                table={table}
+                table={baseTable}
                 inEdit={true}
                 editTable={{}}
+                inFuse={{type: "None", fusedList: [], sepList: []}}
+                setInFuse={() => {}}
                 setEditTable={setEditTable}
-                setOrders={setOrders}
+                setOrders={() => {}}
             />
         );
-        
+
         const tableElement = screen.getByText("1");
         await userEvent.click(tableElement);
-        expect(setEditTable).toHaveBeenCalledWith(table);
+
+        expect(setEditTable).toHaveBeenCalledWith(baseTable);
         expect(container.firstChild).toHaveClass("border-kitchen-button-orange");
     });
 
-    test("clicking table updates orders", async () => {
-        const setEditTable = jest.fn();
+    test("clicking table when not in edit triggers order update", async () => {
         const setOrders = jest.fn();
-        const table = { id: 1, type: "circle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "00:00" };
         render(
             <DroppableTable
-                table={table}
+                table={baseTable}
                 inEdit={false}
                 editTable={{}}
-                setEditTable={setEditTable}
+                inFuse={{type: "None", fusedList: [], sepList: []}}
+                setInFuse={() => {}}
+                setEditTable={() => {}}
                 setOrders={setOrders}
             />
         );
-        
+
         const tableElement = screen.getByText("1");
         await userEvent.click(tableElement);
 
         expect(setOrders).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    test("renders correct time", () => {
-        const table = { id: 1, type: "rectangle", w: 100, h: 100, left: 50, top: 50, plates: 2, time: "15:30" };
+    test("clicking table when inFuse.type is Fuse updates fusedList", async () => {
+        const setInFuse = jest.fn();
+        const inFuseState = {type: "Fuse", fusedList: [], sepList: []};
+
         render(
             <DroppableTable
-                table={table}
+                table={baseTable}
                 inEdit={false}
                 editTable={{}}
+                inFuse={inFuseState}
+                setInFuse={setInFuse}
                 setEditTable={() => {}}
                 setOrders={() => {}}
             />
         );
+
+        const tableElement = screen.getByText("1");
+        await userEvent.click(tableElement);
+
+        expect(setInFuse).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    test("renders correct time", () => {
+        const tableWithTime = {...baseTable, time: "15:30"};
+
+        render(
+            <DroppableTable
+                table={tableWithTime}
+                inEdit={false}
+                editTable={{}}
+                inFuse={{type: "None", fusedList: [], sepList: []}}
+                setInFuse={() => {}}
+                setEditTable={() => {}}
+                setOrders={() => {}}
+            />
+        );
+
         expect(screen.getByText("15:30")).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Describe your changes

Added the possibility to fuse tables, or to separate fused tables via the already existing buttons.

## How to test the feature

Go to the table page, and place tables in the already existing editing mode. Then click on the Fuse button, select two tables, and click on "Fusionner". Click on "Annuler", then select the Separate button, select the fused table, and click on "Séparer".

## Issue ticket number and link

Closes #89 

## Checklist before requesting a review
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
