### PR TITLE
feat: include tableId in orders state update

### DIFF
--- a/src/Components/CurrentCommand/CurrentCommand.js
+++ b/src/Components/CurrentCommand/CurrentCommand.js
@@ -285,8 +285,6 @@ function Footer({ config, orders, setOrders, setConfig, price, priceLess, payLis
             served: false,
         };
 
-        console.log(orders.tableId);
-
         if (orders.orderId !== null) {
             await fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders/${orders.orderId}`, {
                 method: 'PUT',

--- a/src/Components/CurrentCommand/CurrentCommand.js
+++ b/src/Components/CurrentCommand/CurrentCommand.js
@@ -285,6 +285,8 @@ function Footer({ config, orders, setOrders, setConfig, price, priceLess, payLis
             served: false,
         };
 
+        console.log(orders.tableId);
+
         if (orders.orderId !== null) {
             await fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders/${orders.orderId}`, {
                 method: 'PUT',
@@ -302,7 +304,7 @@ function Footer({ config, orders, setOrders, setConfig, price, priceLess, payLis
                 console.log(error);
             });
         } else {
-            await fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders/`, {
+            await fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders${orders.tableId ? `?idTable=${orders.tableId}` : ''}/`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${localStorage.getItem("token")}` },
                 body: JSON.stringify(obj)

--- a/src/Components/CurrentCommand/CurrentCommand.js
+++ b/src/Components/CurrentCommand/CurrentCommand.js
@@ -302,7 +302,7 @@ function Footer({ config, orders, setOrders, setConfig, price, priceLess, payLis
                 console.log(error);
             });
         } else {
-            await fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders${orders.tableId ? `?idTable=${orders.tableId}` : ''}/`, {
+            await fetch(`http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders${orders.tableId ? `?idTable=${orders.tableId}` : ''}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${localStorage.getItem("token")}` },
                 body: JSON.stringify(obj)

--- a/src/Components/TablesView/DroppableTable.js
+++ b/src/Components/TablesView/DroppableTable.js
@@ -42,7 +42,7 @@ function DroppableTable({table, inEdit, editTable, inFuse, setInFuse, setEditTab
             setBorder("border-kitchen-button-orange")
             setEditTable(table)
         } else {
-            setOrders((Order) => ({...Order, number: table.id.toString()}));
+            setOrders((Order) => ({...Order, number: table.id.toString(), tableId: table.id}));
         }
     };
 

--- a/src/__tests__/Components/CurrentCommand.test.js
+++ b/src/__tests__/Components/CurrentCommand.test.js
@@ -159,7 +159,7 @@ describe('CurrentCommand', () => {
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledTimes(1);
             expect(global.fetch).toHaveBeenCalledWith(
-                `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders/`,
+                `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders${orders.tableId ? `?idTable=${orders.tableId}` : ''}`,
                 expect.objectContaining({
                     method: 'POST',
                     body: expect.any(String),
@@ -226,7 +226,7 @@ describe('CurrentCommand', () => {
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledTimes(1);
             expect(global.fetch).toHaveBeenCalledWith(
-                `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders/`,
+                `http://${process.env.REACT_APP_BACKEND_URL}:${process.env.REACT_APP_BACKEND_PORT}/api/1/orders${orders.tableId ? `?idTable=${orders.tableId}` : ''}`,
                 expect.objectContaining({
                     method: 'POST',
                     body: expect.any(String),


### PR DESCRIPTION
## Describe your changes
TableId is stored in the order object when is create from a table and then send with the order upon creation when appropriate.
## How to test the feature
Select a table to create an order, fill the order and send it. The orderId should appear in the table in the pos_config object stored in the DB.
## Issue ticket number and link
Closes #124 
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
