### PR TITLE
fix: update order structure in payment

### DIFF
--- a/src/Components/LayoutFooter/LayoutFooter.js
+++ b/src/Components/LayoutFooter/LayoutFooter.js
@@ -69,7 +69,7 @@ function Footer({ buttons, price, config, setConfig, priceLess, setOrders, activ
                 </div>
             ) : (
                 <div className='w-1/4 h-full bg-kitchen-yellow flex justify-center items-center p-3 shadow-[inset_0_10px_50px_-20px_rgba(0,0,0,0.7)]'>
-                    <div className='w-full h-full flex justify-center items-center truncate text-4xl font-bold text-kitchen-blue cursor-pointer' onClick={() => { handlePayement(); setPriceLess(0); setPayList([]); setConfig(prevConfig => ({ ...prevConfig, payement: !prevConfig.payement })); setOrders([{nb: "42"}, [], {id_restaurant: 4}, {channel: "En salle"}]); navigate(!config.payement ? '/dashboard/pay' : '/dashboard'); }}>
+                    <div className='w-full h-full flex justify-center items-center truncate text-4xl font-bold text-kitchen-blue cursor-pointer' onClick={() => { handlePayement(); setPriceLess(0); setPayList([]); setConfig(prevConfig => ({ ...prevConfig, payement: !prevConfig.payement })); setOrders({number: "42", channel: "Sur place", orderId: null, food: [], tmp: {}}); navigate(!config.payement ? '/dashboard/pay' : '/dashboard'); }}>
                         Terminée
                     </div>
                 </div>


### PR DESCRIPTION
## Describe your changes
When a payment is made, the empty created to reset the POS is now compliant with the order storage refactoring done in #128 
## How to test the feature
1. Create an order
2. Fully pay it
3. Click on "terminé"
-> If there's no error, it works.
## Issue ticket number and link
Closes #156 
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
