### PR TITLE
fix: Fused tables can now be stored and loaded correctly, with corres…

### DIFF
--- a/src/Components/TablesView/DroppableTable.js
+++ b/src/Components/TablesView/DroppableTable.js
@@ -76,7 +76,15 @@ function DroppableTable({table, inEdit, editTable, inFuse, setInFuse, setEditTab
         };
     };
       
-    
+    const getTotalPlates = (table) => {
+        let total = table.plates || 0;
+        if (table.fused && table.fused.length > 0) {
+            for (const fusedTable of table.fused) {
+                total += getTotalPlates(fusedTable);
+            }
+        }
+        return total;
+    };
 
     useEffect(() => {
         if (!inFuse.fusedList.includes(table)) {
@@ -97,7 +105,7 @@ function DroppableTable({table, inEdit, editTable, inFuse, setInFuse, setEditTab
     return (
         <div onClick={() => onTableClick(table.orderId)} name={table.id} className={`${table.type === "circle" ? "rounded-full" : ""} border-4 absolute col-span-1 grid grid-flow-row ${inEdit === true ? `bg-grey-bg ${border} grid-rows-2` : table.time === "00:00" ? `bg-kitchen-green ${fuseBorder} grid-rows-3` : `bg-kitchen-yellow ${fuseBorder} grid-rows-3`} justify-center justify-items-center`} style={{width: table.w, height: table.h, top: table.top, left: table.left}}>   
             <div className={`${table.type === "circle" ? (table.id.length > 5 ? "text-xl" : "text-2xl") : (table.id.length > 5 ? "text-2xl" : "text-3xl")} row-span-1 self-center font-bold`}>{table.id}</div>
-            <div className={`${table.type === "circle" ? "text-xl" : "text-2xl"} row-span-1 self-center`}>{table.plates} {table.type === "rectangle" ? "couverts" : "couv."}</div>
+            <div className={`${table.type === "circle" ? "text-xl" : "text-2xl"} row-span-1 self-center`}>{getTotalPlates(table)} {table.type === "rectangle" ? "couverts" : "couv."}</div>
             {inEdit === false ? table.time === "00:00" ?
                 <div className="row-span-1 self-center text-1xl">{table.type === "rectangle" ? "Disponible" : "Dispo."}</div>
                 : <div className="row-span-1 text-1xl">{calculateWaitingTime(table.time).hours}:{calculateWaitingTime(table.time).minutes}</div> 

--- a/src/Components/TablesView/TablesPanel.js
+++ b/src/Components/TablesView/TablesPanel.js
@@ -23,10 +23,20 @@ function PlatesButton ({ editTable, setEditTable }) {
         }));
     };
 
+    const getTotalPlates = (table) => {
+        let total = table.plates || 0;
+        if (table.fused && table.fused.length > 0) {
+            for (const fusedTable of table.fused) {
+                total += getTotalPlates(fusedTable);
+            }
+        }
+        return total;
+    };
+
     return (
         <div className="grid grid-flow-col pt-5">
             <div className="text-white text-4xl">
-                {`Couverts : ${editTable.plates}`}
+                {`Couverts : ${getTotalPlates(editTable)}`}
             </div>
             <button onClick={() => handleAdd()} className="text-white text-4xl border-white border-y-2 border-l-2 border-r rounded-l-lg">+</button>
             <button onClick={() => handleDel()} className="text-white text-4xl border-white border-y-2 border-r-2 rounded-r-lg">-</button>

--- a/src/Components/TablesView/TablesView.js
+++ b/src/Components/TablesView/TablesView.js
@@ -11,9 +11,9 @@ import DroppableTable from "./DroppableTable";
 import { loadTableBoard } from "../../Pages/Loading/Loading";
 
 const TableList = [
-    {type: "square", plates: 2, w: 100, h: 100, time: "00:00", fused: false},
-    {type: "circle", plates: 2, w: 100, h: 100, time: "00:00", fused: false},
-    {type: "rectangle", plates: 4, w: 200, h: 100, time: "00:00", fused: false}
+    {type: "square", plates: 2, w: 100, h: 100, time: "00:00", fused: []},
+    {type: "circle", plates: 2, w: 100, h: 100, time: "00:00", fused: []},
+    {type: "rectangle", plates: 4, w: 200, h: 100, time: "00:00", fused: []}
 ]
 
 /**
@@ -107,9 +107,9 @@ export default function TablesView({ orders, setOrders, board, setBoard, orderSe
         setIsFirstRender(false);
     }, [setBoard]);
 
-    const saveTable = () => {
+    const createConfigBoard = (board) => {
         let configBoard = board.map((table) => {
-            return {
+            let obj = {
                 x: table.left,
                 y: table.top,
                 name: table.id.toString(),
@@ -119,7 +119,19 @@ export default function TablesView({ orders, setOrders, board, setBoard, orderSe
                 time: table.time,
                 orderId: table.orderId ? table.orderId : null,
             }
+            if (table.fused.length > 0) {
+                obj = {
+                    ...obj,
+                    fused: createConfigBoard(table.fused)
+                }
+            }
+            return obj
         })
+        return configBoard;
+    }
+
+    const saveTable = () => {
+        let configBoard = createConfigBoard(board);
         const {innerWidth: width, innerHeight: height} = window;
         let config = {
             tables: configBoard,


### PR DESCRIPTION
…t sizes and plates, and can be separated after loading

## Describe your changes

Updated all the tables view components, to use the new table DTO.

## How to test the feature

Fuse a table, reload the POS. The fused table should still be here, and you can now separate it.

## Issue ticket number and link

#160 

## Checklist before requesting a review
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
